### PR TITLE
don't log anything in constructors

### DIFF
--- a/src/lib/CardSigner.js
+++ b/src/lib/CardSigner.js
@@ -23,15 +23,15 @@ var log2out = require('log2out');
 
 var CardSigner = function(privatePem, cardHasher) {
 	this.logger = log2out.getLogger('CardSigner');
-	if (settings.keys.privatePem === "" && !privatePem){
-		this.logger.error("Incorrect private key, please provide a valid one.");
-	} else {
-		this.privatePem = privatePem || new Buffer(settings.keys.privatePem, 'base64').toString("utf-8");
-	}
+	this.privatePem = privatePem || new Buffer(settings.keys.privatePem, 'base64').toString("utf-8");
 	this.cardHasher = cardHasher || new CardHasher();
 };
 
 CardSigner.prototype.sign = function(card, signerInjected) {
+	if (settings.keys.privatePem === "") {
+		this.logger.error("Incorrect private key, please provide a valid one.");
+	}
+
 	var hash = this.cardHasher.getHash(card);
 	this.signer = signerInjected || require('crypto').createSign('RSA-SHA256');
 	this.signer.update(hash);

--- a/src/lib/RsaVerifier.js
+++ b/src/lib/RsaVerifier.js
@@ -22,14 +22,14 @@ var log2out = require('log2out');
 
 var RsaVerifier = function(publicPem) {
 	this.logger = log2out.getLogger('RsaVerifier');
-	if (settings.keys.publicPem === "" && !publicPem){
-		this.logger.error("Incorrect public key, please provide a valid one.");
-	} else {
-		this.publicPem = publicPem || new Buffer(settings.keys.publicPem, 'base64').toString("utf-8");
-	}
+	this.publicPem = publicPem || new Buffer(settings.keys.publicPem, 'base64').toString("utf-8");
 };
 
 RsaVerifier.prototype.verify = function(hash, signature, verifierInjected) {
+	if (settings.keys.publicPem) {
+		this.logger.error("Incorrect public key, please provide a valid one.");
+	}
+
 	this.verifier = verifierInjected || require('crypto').createVerify('RSA-SHA256');
 	this.verifier.update(hash);
 	return this.verifier.verify(this.publicPem, signature, 'base64');


### PR DESCRIPTION
It is causing a side-effect in chat where the authentication doesn't
work anymore when not having the keys because the error is logged to
STDOUT and the ejabberd daemon needs to read STDOUT and it is choking on
the log error. This didn't happen when the keys were there but now that
some components only have the public key they were complaining about not
having the private key.
